### PR TITLE
testing altering pre-publish-hook and revert last test

### DIFF
--- a/.github/workflows/scripts/pre-publish-hook
+++ b/.github/workflows/scripts/pre-publish-hook
@@ -12,7 +12,7 @@ f=Shippo/Shippo.csproj
 echo updating $f...
 condition="'\$(GITHUB_ACTIONS)' == 'true'"
 yq -i -o xml -p xml '
-  ( del( .Project.ItemGroup.None | select(.+@Include == "..\docs\**\*") )
+  ( del( .Project.ItemGroup[0] | select(.+@Include == "..\docs\**\*") )
   | .Project.PropertyGroup = [
       .Project.PropertyGroup,
       [

--- a/.github/workflows/scripts/pre-publish-hook
+++ b/.github/workflows/scripts/pre-publish-hook
@@ -12,7 +12,7 @@ f=Shippo/Shippo.csproj
 echo updating $f...
 condition="'\$(GITHUB_ACTIONS)' == 'true'"
 yq -i -o xml -p xml '
-  ( del( .Project.ItemGroup.None[] | select(.+@Include == "..\docs\**\*") )
+  ( del( .Project.ItemGroup.None | select(.+@Include == "..\docs\**\*") )
   | .Project.PropertyGroup = [
       .Project.PropertyGroup,
       [
@@ -40,12 +40,12 @@ yq -i -o xml -p xml '
       {
         "None": [
           {
-            "+@Include": "..\\LICENSE",
+            "+@Include": "..\LICENSE",
             "+@Pack": "true",
             "+@PackagePath": "\\"
           },
           {
-            "+@Include": "..\\res\\shippo.png",
+            "+@Include": "..\res\shippo.png",
             "+@Pack": "true",
             "+@PackagePath": "\\"
           }


### PR DESCRIPTION
Jira Ticket: https://shippo.atlassian.net/browse/CET-317


**Description:**
Change in this [PR](https://github.com/goshippo/shippo-csharp-sdk/pull/11/files#diff-44aa0102317c7c6ae6981e1fb3fc4c2ce4b3365b52e8fb00894e5a50b1688648R30-R32) that resulted in 2 ItemGroups compared to old versions having 1 ItemGroup surfaced this error (screenshot below):
![Screenshot 2024-10-10 at 2 37 05 PM](https://github.com/user-attachments/assets/8ca61551-4f61-4461-92a0-f2373a77f2f9)


**Testing:**
- Captured last known working version of Shippo/Shippo.csproj --> tested existing pre-publish-hook script (specifically yq portion).
- Replicated but with current version of Shippo/Shippo.csproj
- Altered yq portion of script based on having 2 ItemGroups (array) compared to original version with 1 ItemGroup.
- Compared versions that were created from yq and show similar formatting for result ItemGroups. (see screenshot below, current (left) vs old copy (right))
![Screenshot 2024-10-10 at 2 41 47 PM](https://github.com/user-attachments/assets/ed6ef753-97ad-411e-b453-972a69e19cb1)
