### PR TITLE
chore: release Shippo v5.0.0-beta.13

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -109,3 +109,13 @@ Based on:
 - [csharp v5.0.0-beta.9] .
 ### Releases
 - [NuGet v5.0.0-beta.9] https://www.nuget.org/packages/Shippo/5.0.0-beta.9 - .
+
+## 2026-03-18 14:54:48
+### Changes
+Based on:
+- OpenAPI Doc
+- Speakeasy CLI 1.447.0 (2.463.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [csharp v5.0.0-beta.13] .
+### Releases
+- [NuGet v5.0.0-beta.13] https://www.nuget.org/packages/Shippo/5.0.0-beta.13 - .


### PR DESCRIPTION
Adds RELEASES.md entry for v5.0.0-beta.13 to trigger the Publish workflow and push to NuGet.

Merging this PR will auto-publish `Shippo 5.0.0-beta.13` to NuGet via the existing Publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `RELEASES.md` to add a new release entry; no runtime code changes. Risk is limited to potentially triggering the publish workflow unintentionally if merged.
> 
> **Overview**
> Adds a new `RELEASES.md` entry for **`csharp v5.0.0-beta.13`** and its corresponding **NuGet `Shippo/5.0.0-beta.13`** release link (used to trigger the publish workflow).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a51b18d9243059d28ea3b1d3e0fbc3019708049b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->