### PR TITLE
fix(ci): remove pinned Speakeasy version, add dotnet_version to generate workflow

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -22,7 +22,7 @@ jobs:
     with:
       force: ${{ github.event.inputs.force }}
       mode: pr
-      speakeasy_version: 1.447.0
+      dotnet_version: "8.0.x"
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -109,3 +109,13 @@ Based on:
 - [csharp v5.0.0-beta.9] .
 ### Releases
 - [NuGet v5.0.0-beta.9] https://www.nuget.org/packages/Shippo/5.0.0-beta.9 - .
+
+## 2026-03-18 14:54:48
+### Changes
+Based on:
+- OpenAPI Doc
+- Speakeasy CLI 1.447.0 (2.463.0) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [csharp v5.0.0-beta.13] .
+### Releases
+- [NuGet v5.0.0-beta.13] https://www.nuget.org/packages/Shippo/5.0.0-beta.13 - .


### PR DESCRIPTION
## What

- Removes `speakeasy_version: 1.447.0` pin from the Generate workflow
- Adds `dotnet_version: "8.0.x"` to the Generate workflow

## Why

`speakeasy_version` is **deprecated** in `sdk-generation-action@v15` — the action now manages its own CLI version internally. Our pin to `v1.447.0` caused the Generate workflow to fail with:

```
unknown flag: --skip-testing
failed to run with version v1.447.0: exit status 1
```

The `--skip-testing` flag was added to the Speakeasy CLI in a version newer than `v1.447.0`, and `@v15` now always passes it.

`dotnet_version: "8.0.x"` is added to match the publish workflow — the generation workflow defaults to .NET 5.x for C# compilation steps.

## Note on null deserialization

The reason we originally pinned `v1.447.0` was a null deserialization regression in `v1.682.0`. Since the Generate workflow runs in `mode: pr` (creates a PR, doesn't auto-merge), **we can review the generated code before merging** to verify the regression is resolved in the current latest version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI workflow behavior changes by removing the pinned Speakeasy CLI version, which can affect generated SDK output and generator flags. Also updates the generation environment to use .NET 8, which could surface build/compatibility differences.
> 
> **Overview**
> Updates the `Generate` GitHub Action workflow to **stop pinning** `speakeasy_version` (letting `sdk-generation-action@v15` manage the CLI version) and to explicitly run C# generation with `dotnet_version: "8.0.x"`.
> 
> Adds a new entry in `RELEASES.md` documenting the latest generated C# / NuGet release (`v5.0.0-beta.13`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b901d16a2f9f85462771031f8502a65877f467c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->